### PR TITLE
get_estimator_params can work with any sklearn estimator, removing the restriction for regressor or classifier or kmeans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## neptune-sklearn 0.1.2
+
+* `get_estimator_params` works no with any scikit-learn estimator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## neptune-sklearn 0.1.2
 
-* `get_estimator_params` works no with any scikit-learn estimator.
+### Changes
+* `get_estimator_params` works no with any scikit-learn estimator. ([#3](https://github.com/neptune-ai/neptune-sklearn/pull/3))

--- a/neptune_sklearn/impl/__init__.py
+++ b/neptune_sklearn/impl/__init__.py
@@ -41,7 +41,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 from scikitplot.estimators import plot_learning_curve
 from scikitplot.metrics import plot_precision_recall
-from sklearn.base import is_classifier, is_regressor
+from sklearn.base import is_classifier, is_regressor, BaseEstimator
 from sklearn.cluster import KMeans
 from sklearn.metrics import explained_variance_score, max_error, mean_absolute_error, precision_recall_fscore_support, \
     r2_score
@@ -303,8 +303,7 @@ def get_estimator_params(estimator):
             run = neptune.init(project='my_workspace/my_project')
             run['estimator/params'] = npt_utils.get_estimator_params(rfr)
     """
-    assert is_regressor(estimator) or is_classifier(estimator) or isinstance(estimator, KMeans), \
-        'Estimator should be sklearn regressor, classifier or kmeans clusterer.'
+    assert isinstance(estimator, BaseEstimator), 'Estimator should be a sklearn estimator.'
 
     return estimator.get_params()
 


### PR DESCRIPTION
No need for this restriction, any sklearn estimator would follow the interface and have the `get_params` method https://scikit-learn.org/stable/modules/generated/sklearn.base.BaseEstimator.html#sklearn.base.BaseEstimator