### PR TITLE
fix imports from impl package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Changes
 - Moved neptune_sklearn package to src dir ([#5](https://github.com/neptune-ai/neptune-sklearn/pull/5))
 
+
+### Fixes
+- Fixed imports from `neptune_sklearn.impl` -> now possible to import from `neptune_sklearn` ([#7](https://github.com/neptune-ai/neptune-sklearn/pull/7))
+
 ## neptune-sklearn 0.1.2
 
 ### Changes

--- a/src/neptune_sklearn/__init__.py
+++ b/src/neptune_sklearn/__init__.py
@@ -14,7 +14,27 @@
 # limitations under the License.
 #
 
-from ._version import get_versions
-
-__version__ = get_versions()["version"]
-del get_versions
+from neptune_sklearn.impl import (
+    __version__,
+    create_class_prediction_error_chart,
+    create_classification_report_chart,
+    create_classifier_summary,
+    create_confusion_matrix_chart,
+    create_cooks_distance_chart,
+    create_feature_importance_chart,
+    create_kelbow_chart,
+    create_kmeans_summary,
+    create_learning_curve_chart,
+    create_precision_recall_chart,
+    create_prediction_error_chart,
+    create_regressor_summary,
+    create_residuals_chart,
+    create_roc_auc_chart,
+    create_silhouette_chart,
+    get_cluster_labels,
+    get_estimator_params,
+    get_pickled_model,
+    get_scores,
+    get_test_preds,
+    get_test_preds_proba,
+)

--- a/src/neptune_sklearn/impl/__init__.py
+++ b/src/neptune_sklearn/impl/__init__.py
@@ -35,6 +35,7 @@ __all__ = [
     "get_scores",
     "get_test_preds",
     "get_test_preds_proba",
+    "__version__",
 ]
 
 import matplotlib.pyplot as plt

--- a/src/neptune_sklearn/impl/__init__.py
+++ b/src/neptune_sklearn/impl/__init__.py
@@ -78,6 +78,10 @@ except ImportError:
     # neptune-client=1.0.0 package structure
     import neptune
 
+from neptune_sklearn._version import get_versions
+
+__version__ = get_versions()["version"]
+
 
 def create_regressor_summary(regressor, X_train, X_test, y_train, y_test, nrows=1000, log_charts=True):
     """Create sklearn regressor summary.


### PR DESCRIPTION
Now it would be possible to import those functions directly from neptune_sklearn package, instead of neptune_sklearn.impl