### PR TITLE
Fix for Yellowbrick-Matplotlib incompatibility

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -19,7 +19,8 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       run: pip install -e .[dev]
       shell: bash
-
+      env:
+        MPLLOCALFREETYPE: "1"
     - name: Setup Graphviz
       uses: ts-graphviz/setup-graphviz@v1
       with:

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -21,11 +21,6 @@ runs:
       shell: bash
       env:
         MPLLOCALFREETYPE: "1"
-    # - name: Setup Graphviz
-    #   uses: ts-graphviz/setup-graphviz@v1
-    #   with:
-    #     ubuntu-skip-apt-update: true
-    #     macos-skip-brew-update: true
 
     - name: Run tests
       working-directory: ${{ inputs.working_directory }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -21,11 +21,11 @@ runs:
       shell: bash
       env:
         MPLLOCALFREETYPE: "1"
-    - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v1
-      with:
-        ubuntu-skip-apt-update: true
-        macos-skip-brew-update: true
+    # - name: Setup Graphviz
+    #   uses: ts-graphviz/setup-graphviz@v1
+    #   with:
+    #     ubuntu-skip-apt-update: true
+    #     macos-skip-brew-update: true
 
     - name: Run tests
       working-directory: ${{ inputs.working_directory }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.10", "3.12"]
+        exclude:
+          - os: windows-latest
+            python-verson: "3.10"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -25,9 +25,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.10", "3.12"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ["3.8", "3.10", "3.12"]
         exclude:
           - os: windows-latest
-            python-verson: "3.10"
+            python-version: "3.10"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.10", "3.12"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.10"
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]
+        python-version: ["3.8", "3.10", "3.12"]
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## neptune-sklearn 2.1.3
 
+### Fixes
+- Monkey patches [`yellowbrick.regression.CooksDistance.draw()`](https://github.com/DistrictDataLabs/yellowbrick/blob/f7a8e950bd31452ea2f5d402a1c5d519cd163fd5/yellowbrick/regressor/influence.py#L184) to remove unsupported `use_line_collection` matplotlib arg ([#28](https://github.com/neptune-ai/neptune-sklearn/pull/28))
+
 ### Changes
-- Constrained matplotlib to `<3.3` on Python `>=3.12` ([#28](https://github.com/neptune-ai/neptune-sklearn/pull/28))
 - Replaced `print()` with `warnings.warn()` to better capture `stderr`  ([#28](https://github.com/neptune-ai/neptune-sklearn/pull/28))
 
 ## neptune-sklearn 2.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## neptune-sklearn 2.1.3
+
+### Changes
+- Constrained matplotlib to `<3.3` on Python `>=3.12` ([#28](https://github.com/neptune-ai/neptune-sklearn/pull/28))
+- Replaced `print()` with `warnings.warn()` to better capture `stderr`  ([#28](https://github.com/neptune-ai/neptune-sklearn/pull/28))
+
 ## neptune-sklearn 2.1.2
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ scikit-learn = ">=0.24.1"
 yellowbrick = ">=1.3"
 scikit-plot = ">=0.3.7"
 scipy = "<1.12" # Fixes #24 (https://github.com/neptune-ai/neptune-sklearn/issues/24)
+matplotlib = { version = "<3.3", python = "<3.12"} # Fixes https://github.com/DistrictDataLabs/yellowbrick/issues/1312
 
 # dev
 pre-commit = { version = "*", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ scikit-learn = ">=0.24.1"
 yellowbrick = ">=1.3"
 scikit-plot = ">=0.3.7"
 scipy = "<1.12" # Fixes #24 (https://github.com/neptune-ai/neptune-sklearn/issues/24)
-matplotlib = { version = "<3.3", python = "<3.12"} # Fixes https://github.com/DistrictDataLabs/yellowbrick/issues/1312
 
 # dev
 pre-commit = { version = "*", optional = true }

--- a/src/neptune_sklearn/impl/__init__.py
+++ b/src/neptune_sklearn/impl/__init__.py
@@ -86,6 +86,8 @@ except ImportError:
     )
     from neptune.new.utils import stringify_unsupported
 
+from warnings import warn
+
 
 def create_regressor_summary(regressor, X_train, X_test, y_train, y_test, nrows=1000, log_charts=True):
     """Creates scikit-learn regressor summary.
@@ -455,7 +457,7 @@ def get_test_preds_proba(classifier, X_test=None, y_pred_proba=None, nrows=1000)
         try:
             y_pred_proba = classifier.predict_proba(X_test)
         except Exception as e:
-            print("This classifier does not provide predictions probabilities. Error: {}".format(e))
+            warn(f"This classifier does not provide predictions probabilities. Error: {e}")
             return
 
     df = pd.DataFrame(data=y_pred_proba, columns=classifier.classes_)
@@ -590,7 +592,7 @@ def create_learning_curve_chart(regressor, X_train, y_train):
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log learning curve chart. Error: {}".format(e))
+        warn(f"Did not log learning curve chart. Error: {e}")
 
     return chart
 
@@ -633,7 +635,7 @@ def create_feature_importance_chart(regressor, X_train, y_train):
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log feature importance chart. Error: {}".format(e))
+        warn(f"Did not log feature importance chart. Error: {e}")
 
     return chart
 
@@ -678,7 +680,7 @@ def create_residuals_chart(regressor, X_train, X_test, y_train, y_test):
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log residuals chart. Error: {}".format(e))
+        warn(f"Did not log residuals chart. Error: {e}")
 
     return chart
 
@@ -723,7 +725,7 @@ def create_prediction_error_chart(regressor, X_train, X_test, y_train, y_test):
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log prediction error chart. Error: {}".format(e))
+        warn(f"Did not log prediction error chart. Error: {e}")
 
     return chart
 
@@ -765,7 +767,7 @@ def create_cooks_distance_chart(regressor, X_train, y_train):
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log cooks distance chart. Error: {}".format(e))
+        warn(f"Did not log cooks distance chart. Error: {e}")
 
     return chart
 
@@ -812,7 +814,7 @@ def create_classification_report_chart(classifier, X_train, X_test, y_train, y_t
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log Classification Report chart. Error: {}".format(e))
+        warn(f"Did not log Classification Report chart. Error: {e}")
 
     return chart
 
@@ -859,7 +861,7 @@ def create_confusion_matrix_chart(classifier, X_train, X_test, y_train, y_test):
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log Confusion Matrix chart. Error: {}".format(e))
+        warn(f"Did not log Confusion Matrix chart. Error: {e}")
 
     return chart
 
@@ -904,7 +906,7 @@ def create_roc_auc_chart(classifier, X_train, X_test, y_train, y_test):
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log ROC-AUC chart. Error {}".format(e))
+        warn(f"Did not log ROC-AUC chart. Error {e}")
 
     return chart
 
@@ -943,9 +945,9 @@ def create_precision_recall_chart(classifier, X_test, y_test, y_pred_proba=None)
         try:
             y_pred_proba = classifier.predict_proba(X_test)
         except Exception as e:
-            print(
-                "Did not log Precision-Recall chart: this classifier does not provide predictions probabilities."
-                "Error {}".format(e)
+            warn(
+                f"""Did not log Precision-Recall chart: this classifier does not provide predictions probabilities.
+                Error {e}"""
             )
             return chart
 
@@ -955,7 +957,7 @@ def create_precision_recall_chart(classifier, X_test, y_test, y_pred_proba=None)
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log Precision-Recall chart. Error {}".format(e))
+        warn(f"Did not log Precision-Recall chart. Error {e}")
 
     return chart
 
@@ -1002,7 +1004,7 @@ def create_class_prediction_error_chart(classifier, X_train, X_test, y_train, y_
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log Class Prediction Error chart. Error {}".format(e))
+        warn(f"Did not log Class Prediction Error chart. Error {e}")
 
     return chart
 
@@ -1088,7 +1090,7 @@ def create_kelbow_chart(model, X, **kwargs):
         chart = File.as_image(fig)
         plt.close(fig)
     except Exception as e:
-        print("Did not log KMeans elbow chart. Error {}".format(e))
+        warn(f"Did not log KMeans elbow chart. Error {e}")
 
     return chart
 
@@ -1140,6 +1142,7 @@ def create_silhouette_chart(model, X, **kwargs):
             charts.append(File.as_image(fig))
             plt.close(fig)
         except Exception as e:
-            print("Did not log Silhouette Coefficients chart. Error {}".format(e))
+            warn(f"Did not log Silhouette Coefficients chart. Error {e}")
 
+    return FileSeries(charts)
     return FileSeries(charts)

--- a/src/neptune_sklearn/impl/__init__.py
+++ b/src/neptune_sklearn/impl/__init__.py
@@ -730,7 +730,7 @@ def create_prediction_error_chart(regressor, X_train, X_test, y_train, y_test):
     return chart
 
 
-def __monkey_draw(self):
+def _monkey_draw(self):
     """
     Monkey patches `yellowbrick.regressor.CooksDistance.draw()`
     to remove unsupported matplotlib argument `use_line_collection`.
@@ -763,7 +763,7 @@ def __monkey_draw(self):
     return self.ax
 
 
-CooksDistance.draw = __monkey_draw
+CooksDistance.draw = _monkey_draw
 
 
 def create_cooks_distance_chart(regressor, X_train, y_train):
@@ -1180,5 +1180,4 @@ def create_silhouette_chart(model, X, **kwargs):
         except Exception as e:
             warn(f"Did not log Silhouette Coefficients chart. Error {e}")
 
-    return FileSeries(charts)
     return FileSeries(charts)

--- a/src/neptune_sklearn/impl/__init__.py
+++ b/src/neptune_sklearn/impl/__init__.py
@@ -730,6 +730,42 @@ def create_prediction_error_chart(regressor, X_train, X_test, y_train, y_test):
     return chart
 
 
+def monkey_draw(self):
+    """
+    Monkey patches `yellowbrick.regressor.CooksDistance.draw()`
+    to remove unsupported matplotlib argument `use_line_collection`.
+
+    Draws a stem plot where each stem is the Cook's Distance of the instance at the
+    index specified by the x axis. Optionaly draws a threshold line.
+    """
+    # Draw a stem plot with the influence for each instance
+    _, _, baseline = self.ax.stem(
+        self.distance_,
+        linefmt=self.linefmt,
+        markerfmt=self.markerfmt,
+        # use_line_collection=True
+    )
+
+    # No padding on either side of the instance index
+    self.ax.set_xlim(0, len(self.distance_))
+
+    # Draw the threshold for most influential points
+    if self.draw_threshold:
+        label = r"{:0.2f}% > $I_t$ ($I_t=\frac {{4}} {{n}}$)".format(self.outlier_percentage_)
+        self.ax.axhline(
+            self.influence_threshold_,
+            ls="--",
+            label=label,
+            c=baseline.get_color(),
+            lw=baseline.get_linewidth(),
+        )
+
+    return self.ax
+
+
+CooksDistance.draw = monkey_draw
+
+
 def create_cooks_distance_chart(regressor, X_train, y_train):
     """Creates cooks distance chart.
 

--- a/src/neptune_sklearn/impl/__init__.py
+++ b/src/neptune_sklearn/impl/__init__.py
@@ -730,7 +730,7 @@ def create_prediction_error_chart(regressor, X_train, X_test, y_train, y_test):
     return chart
 
 
-def monkey_draw(self):
+def __monkey_draw(self):
     """
     Monkey patches `yellowbrick.regressor.CooksDistance.draw()`
     to remove unsupported matplotlib argument `use_line_collection`.
@@ -763,7 +763,7 @@ def monkey_draw(self):
     return self.ax
 
 
-CooksDistance.draw = monkey_draw
+CooksDistance.draw = __monkey_draw
 
 
 def create_cooks_distance_chart(regressor, X_train, y_train):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     from neptune.new import Run, init_run
 
+import matplotlib as mpl
 import pytest
 from sklearn.cluster import KMeans
 from sklearn.dummy import (
@@ -15,6 +16,8 @@ from sklearn.dummy import (
 from sklearn.model_selection import GridSearchCV
 
 import neptune_sklearn as npt_utils
+
+mpl.use("agg")
 
 
 def test_classifier_summary(iris):


### PR DESCRIPTION
*  Monkey patched [`yellowbrick.regression.CooksDistance.draw()`](https://github.com/DistrictDataLabs/yellowbrick/blob/f7a8e950bd31452ea2f5d402a1c5d519cd163fd5/yellowbrick/regressor/influence.py#L184) to remove unsupported `use_line_collection` matplotlib arg ([#28](https://github.com/neptune-ai/neptune-sklearn/pull/28))
* Expanded e2e test matrix to include Python 3.8, 3.10, and 3.12
* Replaced `print()` with `warning()` to capture stderr