### PR TITLE
fix: Create Visualizer from a copy of the regressor to prevent updates to original regressor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         args: [--settings-path, pyproject.toml]
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 24.4.2
     hooks:
       - id: black
         args: [--config, pyproject.toml]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## neptune-sklearn 2.1.4
 
 ### Fixes
-- `create_feature_importance_chart()` now does not update the original coefficients of the regressor ([#29](https://github.com/neptune-ai/neptune-sklearn/pull/29))
+- `create_feature_importance_chart()` now does not update the original coefficients of the regressor ([#30](https://github.com/neptune-ai/neptune-sklearn/pull/30)
 
 ## neptune-sklearn 2.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-sklearn 2.1.4
+
+### Fixes
+- `create_feature_importance_chart()` now does not update the original coefficients of the regressor ([#29](https://github.com/neptune-ai/neptune-sklearn/pull/29))
+
 ## neptune-sklearn 2.1.3
 
 ### Fixes

--- a/src/neptune_sklearn/impl/__init__.py
+++ b/src/neptune_sklearn/impl/__init__.py
@@ -86,6 +86,7 @@ except ImportError:
     )
     from neptune.new.utils import stringify_unsupported
 
+from copy import deepcopy
 from warnings import warn
 
 
@@ -628,7 +629,7 @@ def create_feature_importance_chart(regressor, X_train, y_train):
 
     try:
         fig, ax = plt.subplots()
-        visualizer = FeatureImportances(regressor, is_fitted=True, ax=ax)
+        visualizer = FeatureImportances(deepcopy(regressor), is_fitted=True, ax=ax)
         visualizer.fit(X_train, y_train)
         visualizer.finalize()
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -8,11 +8,13 @@ except ImportError:
 
 import matplotlib as mpl
 import pytest
+from numpy import array_equal
 from sklearn.cluster import KMeans
 from sklearn.dummy import (
     DummyClassifier,
     DummyRegressor,
 )
+from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import GridSearchCV
 
 import neptune_sklearn as npt_utils
@@ -35,12 +37,16 @@ def test_classifier_summary(iris):
 
 def test_regressor_summary(diabetes):
     with init_run() as run:
-        model = DummyRegressor()
+        model = LinearRegression()
         model.fit(diabetes.x_train, diabetes.y_train)
+
+        original_coef = model.coef_
 
         run["summary"] = npt_utils.create_regressor_summary(
             model, diabetes.x_train, diabetes.x_test, diabetes.y_train, diabetes.y_test
         )
+
+        assert array_equal(model.coef_, original_coef), "Original model coefficients modified."
 
         run.wait()
         validate_run(run, log_charts=True)
@@ -48,7 +54,6 @@ def test_regressor_summary(diabetes):
 
 def test_kmeans_summary(iris):
     with init_run() as run:
-
         model = KMeans()
         model.fit(iris.x)
 
@@ -77,7 +82,11 @@ def test_unsupported_object(diabetes):
         )
 
         run["regressor_summary"] = npt_utils.create_regressor_summary(
-            grid_cv, diabetes.x_train, diabetes.x_test, diabetes.y_train, diabetes.y_test
+            grid_cv,
+            diabetes.x_train,
+            diabetes.x_test,
+            diabetes.y_train,
+            diabetes.y_test,
         )
 
         run.wait()


### PR DESCRIPTION
`create_feature_importance_chart()` would instantiate `FeatureImportances()` on the original regressor and then refit the instantiated object. In some cases (as shown in #29), this can update the coefficients of the original model.

This change instantiates `FeatureImportances()` on a deepcopy of the original regressor, preventing any changes to the original.